### PR TITLE
HPCC-15708 Clang build fails due to unexpected semicolons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,18 +424,13 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 
   # Detect if this is Apple's clang
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} -v ERROR_VARIABLE CASS_CLANG_VERSION_INFO)
-  if (${CASS_CLANG_VERSION_INFO} MATCHES "Apple LLVM version ([0-9]+\\.[0-9]+\\.[0-9]+).*")
-    string (REGEX REPLACE "Apple LLVM version ([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" APPLE_CLANG_VERSION ${CASS_CLANG_VERSION_INFO})
-  endif()
-  if (${clang_full_version_string} MATCHES ".*based on LLVM ([0-9]+\\.[0-9]+).*")
-    string (REGEX REPLACE ".*based on LLVM ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION ${CASS_CLANG_VERSION_INFO})
+  if (CASS_CLANG_VERSION_INFO MATCHES "^Apple LLVM")
+    set(CASS_IS_APPLE_CLANG 1)
   else()
-    if (${clang_full_version_string} MATCHES ".*clang version ([0-9]+\\.[0-9]+).*")
-      string (REGEX REPLACE ".*clang version ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION ${CASS_CLANG_VERSION_INFO})
-    endif()
+    set(CASS_IS_APPLE_CLANG 0)
   endif()
 
-  if (CLANG_VERSION VERSION_GREATER 3.6 OR CLANG_VERSION VERSION_EQUAL 3.6 OR APPLE_CLANG_VERSION VERSION_GREATER 6.0)
+  if(NOT CASS_IS_APPLE_CLANG AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER "3.6")
     set(WARNING_COMPILER_FLAGS "${WARNING_COMPILER_FLAGS} -Wno-unused-local-typedef ")
   endif()
 


### PR DESCRIPTION
Last commit (d7bbad) fails clang builds in some environments,
and it seems like this commit was amended (4be751) soon to correct the problem.

This commit simply brings that amended commit, and fixes the problem.

Signed-off-by: Suk Hwan Hong suk.hong@gatech.edu
